### PR TITLE
Feature: auto turn off LEDs

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -7,6 +7,9 @@
 
 #define RGB // Change this to GRB if your colors are off
 
+#define AUTO_TURN_OFF false // Set to true if you want the LEDs to turn off after inactivity
+#define AUTO_TURN_OFF_MINUTES 30 // Set the number of minutes after which the LEDs should turn off if there is no activity
+
 // Settings below ususally don't need to be adjusted unless you have a special situation
 
 // Number of LEDs in the LED strip (usually 150 for MoonBoard Mini, 200 for a standard MoonBoard)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@ RgbColor black(0);
 int state = 0; // Variable to store the current state of the problem string parser
 String problemstring = ""; // Variable to store the current problem string
 bool useadditionalled = false; // Variable to store the additional LED setting
+int problem_loaded_time = 0; // Variable to store the time when a problem was loaded
 
 void setup() {
   Serial.begin(9600);
@@ -242,6 +243,7 @@ void loop() {
         strip.Show(); // Light up all hold (and additional) LEDs
         problemstring = ""; // Reset problem string
         useadditionalled = false; // Reset additional LED option
+        problem_loaded_time = millis(); // Set problem loaded time
         state = 0; // Switch to state 0 (wait for new problem string or configuration)
         Serial.println("---------\n");
         break;
@@ -249,5 +251,17 @@ void loop() {
 
       problemstring = problemstring.substring(pos+1, problemstring.length()); // Remove processed hold from string
     }
+  }
+
+  // When "auto turn off" enabled, clear the LEDs after x minutes of inactivity
+  if (AUTO_TURN_OFF && problem_loaded_time && millis() - problem_loaded_time > AUTO_TURN_OFF_MINUTES * 60000) {
+    Serial.println("---------\n");
+    Serial.println("Turning off LEDs due to inactivity");
+
+    strip.ClearTo(black); // Turn off all LEDs in LED string
+    strip.Show(); // Light up all hold (and additional) LEDs
+    problem_loaded_time = 0; // Reset problem loaded time
+
+    Serial.println("---------\n");
   }
 }


### PR DESCRIPTION
I'm surprised that the moonboard app does not have a way to turn off the LEDs. I guess the idea is you add a hardware switch. But I thought it would be nice if it could be done programmatically, e.g. in case someone forgets to turn off the lights.

So I made a little addition to turn off the LEDs after x minutes of inactivity (configurable in `config.h`).

It's optional and disabled by default, you have to set `AUTO_TURN_OFF` in the config file `config.h` to enable the feature.